### PR TITLE
consistency for white values

### DIFF
--- a/lib/Control.js
+++ b/lib/Control.js
@@ -342,6 +342,7 @@ class Control {
 					green: data.readUInt8(7),
 					blue: data.readUInt8(8)
 				},
+				warm_white: data.readUInt8(9),
 				warm_white_percent: (data.readUInt8(9) / 255) * 100,
 			};
 


### PR DESCRIPTION
I'd like to propose a change of percental display for warm white to its absolute value for a few reasons:
- consistency with the way color values are treated
- consistency with the way how to set the white brightness value (set: 0-255, get: 0-100)
- provide an option to avoid rounding error problems (e.g. set white brightness to 172 (67,45%) which rounds to 67%. This would translate back to 170,85 resp. 171 rounded)

kept warm_white_percent property for compatibility/convenience purposes.