### PR TITLE
Clamp cold white values

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,10 +85,10 @@ Convenience method to call `setPower(true)`.
 Convenience method to call `setPower(false)`.
 
 **setColorAndWarmWhite**(red, green, blue, ww, callback)  
-Sets both color and warm white value at the same time.
+Sets both color and warm white value at the same time. This method will not work on lights that don't support both colors and whites being activated at the same time; use either `setColor` or `setWarmWhite`.
 
 **setColorAndWhites**(red, green, blue, ww, cw, callback)  
-Sets color, warm white as well as cold white values at the same time, if `cold_white_support` is enabled.
+Sets color, warm white as well as cold white values at the same time, if `cold_white_support` is enabled. This method will not work on lights that don't support both colors and whites being being activated at the same time; use either `setColor` or `setWhites`.
 
 **setColor**(red, green, blue, callback)  
 Sets only the color values.

--- a/lib/Control.js
+++ b/lib/Control.js
@@ -283,6 +283,7 @@ class Control {
 
 		let cmd_buf;
 		if (this._options.cold_white_support) {
+			cw = clamp(cw, 0, 255);
 			cmd_buf = Buffer.from([ 0x31, red, green, blue, ww, cw, mask, 0x0f ]);
 		} else {
 			cmd_buf = Buffer.from([ 0x31, red, green, blue, ww, mask, 0x0f ]);


### PR DESCRIPTION
<strike>Fixes some issues that I encountered with some of my bulbs, debugged via network packet capturing. Turns out that `setColorAndWarmWhite` and `setColorAndWhites` weren't applying the mask option.</strike> Additionally, the cold white value should be clamped to [0, 255] like the other color values.